### PR TITLE
Update probe_osp.py for use with draft clean_osp.sh

### DIFF
--- a/clean_osp.sh
+++ b/clean_osp.sh
@@ -1,0 +1,111 @@
+#!/bin/bash -
+#===============================================================================
+#
+#          FILE: clean_osp.sh
+#
+#         USAGE: ./clean_osp.sh
+#
+#   DESCRIPTION: This shell script takes the probe_osp.py output and attempts
+#                to delete the 
+#
+#       OPTIONS: ---
+#  REQUIREMENTS: probe_osp.py installed and functioning, and bash installed
+#                probe_osp.py must have been run with the -c option and
+#                must have output data files for cleaning in the targetted
+#                directory
+#          BUGS: Deletion hierarchy in OSP is not always straightforward
+#         NOTES: ---
+#        AUTHOR: John Apple II (JAII), jappleii@redhat.com
+#  ORGANIZATION: GPS
+#       CREATED: 28/08/23 14:25:38
+#      REVISION: 001
+#===============================================================================
+
+set -o nounset                                  # Treat unset variables as an error
+
+function usage {
+  file=$(basename "$0")
+  echo "$file usage: "
+  echo "  [ -c directory containing the osprobe cleanup data ]"
+  echo ""
+  exit 1
+}
+
+while [[ $# -gt 1 ]]
+do
+    key="$1"
+    case $key in
+      -c)
+      clean_data_directory="$2"
+      shift
+      ;;
+      *)
+      usage
+      shift
+      ;;
+  esac
+  shift
+done
+
+if [ ! -d "${clean_data_directory}" ] ; then
+  echo "clean data directory option \"${clean_data_directory}\" is not a directory"
+  usage
+fi
+
+if [ -e "${clean_data_directory}/users.osprobe.cleanup" ] ; then  
+  xargs -a "${clean_data_directory}/users.osprobe.cleanup" -n 10 openstack user delete
+fi
+
+if [ -e "${clean_data_directory}/fips.osprobe.cleanup" ] ; then  
+  xargs -a "${clean_data_directory}/fips.osprobe.cleanup" -n 1 openstack floating ip delete
+fi
+
+if [ -e "${clean_data_directory}/trunks.osprobe.cleanup" ] ; then
+  while read -r port; do 
+    mytrunk=''
+    mytrunk=$(openstack port show "$port" | grep trunk_details | tr '|' ' ' | sed -e 's/trunk_details//' -e 's/^[ ]\+//' -e 's/[ ]\+$//');
+    if [ "$mytrunk" == "None" ]; then     
+      openstack port delete "$port";   
+    else     
+      mytrunkport=$(echo "$mytrunk" | sed -e "s/'/\"/g" | jq -r .trunk_id );
+      openstack network trunk delete "$mytrunkport";     
+      openstack port delete "$port";   
+    fi
+  done < <(cat "${clean_data_directory}/trunks.osprobe.cleanup")
+fi
+  
+if [ -e "${clean_data_directory}/vms.osprobe.cleanup" ] ; then  
+  xargs -a "${clean_data_directory}/vms.osprobe.cleanup" -n 2 openstack server delete
+fi
+
+if [ -e "${clean_data_directory}/security_groups.osprobe.cleanup" ] ; then  
+  xargs -a "${clean_data_directory}/security_groups.osprobe.cleanup" -n 10 openstack security group delete
+fi
+
+if [ -e "${clean_data_directory}/ports.osprobe.cleanup" ] ; then  
+  xargs -a "${clean_data_directory}/ports.osprobe.cleanup" -n 10 openstack port delete
+fi
+
+if [ -e "${clean_data_directory}/routers.osprobe.cleanup" ] ; then  
+  while read -r r; do
+    openstack router unset --external-gateway "$r"
+    raw_data=$(openstack router show "$r" | grep interfaces_info | grep subnet_id | cut -f 3 -d '|')
+    subnet_ids=$(echo "$raw_data" | jq -r '.[] | .subnet_id')
+    while read -r d; do
+      openstack router remove subnet "$r" "$d"
+    done < "$subnet_ids"
+  done
+fi
+
+if [ -e "${clean_data_directory}/subnets.osprobe.cleanup" ] ; then  
+  xargs -a "${clean_data_directory}/subnets.osprobe.cleanup" -n 10 openstack subnet delete
+fi
+
+if [ -e "${clean_data_directory}/networks.osprobe.cleanup" ] ; then  
+  xargs -a "${clean_data_directory}/networks.osprobe.cleanup" -n 10 openstack network delete
+fi
+
+if [ -e "${clean_data_directory}/stacks.osprobe.cleanup" ] ; then  
+  xargs -a "${clean_data_directory}/stacks.osprobe.cleanup" -n 5 openstack stack delete -y
+fi
+

--- a/clean_osp.sh
+++ b/clean_osp.sh
@@ -47,6 +47,7 @@ do
   shift
 done
 
+
 if [ ! -d "${clean_data_directory}" ] ; then
   echo "clean data directory option \"${clean_data_directory}\" is not a directory"
   usage

--- a/probe_osp.py
+++ b/probe_osp.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
 """
 name:             :probe_osp.py
 description       :checks openstack resources for valid(existing) project id.
@@ -8,14 +7,33 @@ author            :yvarbev@redhat.com
 release           :22/07
 version           :0.1
 """
-
 import argparse
+
+cleanup_files = [
+    "users.osprobe.cleanup",
+    "fips.osprobe.cleanup",
+    "networks.osprobe.cleanup",
+    "ports.osprobe.cleanup",
+    "routers.osprobe.cleanup",
+    "subnets.osprobe.cleanup",
+    "stacks.osprobe.cleanup",
+    "trunks.osprobe.cleanup",
+    "vms.osprobe.cleanup",
+    "security_groups.osprobe.cleanup"]
+
 parser = argparse.ArgumentParser(description='Options for probe_osp.py')
 parser.add_argument('-c', '--cleanup', help='creates individual resource files in the target directory', required=False, type=str, dest='directory')
 args = parser.parse_args()
+
 if args.directory:
     cleanup_bool = True
     print(f"Cleanup files: {cleanup_bool}")
+    import os
+    for file in cleanup_files:
+        filename = f"{args.directory}/{file}"
+        if os.path.exists(filename):
+            print(f"removing stale file {filename}")
+            os.remove(filename)
 else:
     cleanup_bool = False
 
@@ -74,17 +92,20 @@ def probe_users(cloud):
 
 def probe_stacks(cloud):
     stacks = _connect(cloud).list_stacks()
+    failed_stacks = []
     for stack in stacks:
         if 'FAILED' in stack.status:
+            failed_stacks.append(stack.name)
             print('Stacks:')
             print('{}, {}, {}'.format(stack.status, stack.name, stack.status_reason))
             print('~ End ~\n')
-            if cleanup_bool:
-                filename = f"{args.directory}/stacks.osprobe.cleanup"
-                f = open(filename, 'w')
-                for item in stacks:
-                    f.write(item.name + "\n")
-                f.close
+    if cleanup_bool:
+        if len(failed_stacks) > 0:
+            filename = f"{args.directory}/stacks.osprobe.cleanup"
+            f = open(filename, 'w')
+            for item in failed_stacks:
+                f.write(item + "\n")
+            f.close
 
 
 def probe_network(cloud):

--- a/probe_osp.py
+++ b/probe_osp.py
@@ -78,7 +78,7 @@ def probe_users(cloud):
                 sU.append(user.name)
     print('Users:')
     print(len(xU), 'users with no valid project id or email')
-    if cleanup_bool:
+    if cleanup_bool and len(xU) > 0:
         filename = f"{args.directory}/users.osprobe.cleanup"
         f = open(filename, 'w')
         for item in xU:
@@ -95,7 +95,7 @@ def probe_stacks(cloud):
     failed_stacks = []
     for stack in stacks:
         if 'FAILED' in stack.status:
-            failed_stacks.append(stack.name)
+            failed_stacks.append(stack.id)
             print('Stacks:')
             print('{}, {}, {}'.format(stack.status, stack.name, stack.status_reason))
             print('~ End ~\n')


### PR DESCRIPTION
probe_osp.py has been updated to include stack output file

clean_osp.sh is setup to enable cleaning using files output from probe_osp.py with the -c option, attempting to clean using best-guess dependency tree between the investigated entries.

Please note we are still working on attempting to pull volume/snap information from Cinder to enable volume cleanup as well, but we are working on figuring out the API to enable pulling all volume details in probe_osp.py